### PR TITLE
hotfix: fix publish-marketplace workflow checkout

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -374,11 +374,8 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v5
               with:
-                  ref: ${{ github.ref }}
+                  fetch-depth: 0
                   token: ${{ secrets.GITHUB_TOKEN }}
-
-            - name: Pull latest changes
-              run: git pull origin HEAD
 
             - name: Use Node.js 20.x
               uses: actions/setup-node@v6


### PR DESCRIPTION
## 🐛 Hotfix: Release Workflow Issue

### Problem
The `publish-marketplace` job in the release workflow was failing because it was using `ref` parameter and trying to pull changes that don't exist in the repository state at that point.

### Solution
- Removed unnecessary `ref` parameter from checkout
- Removed redundant `git pull` command
- Simplified to use `fetch-depth: 0` for full history

### Changes
- **File**: `.github/workflows/release.yml`
- **Job**: `publish-marketplace`
- **Action**: Simplified checkout step

### Testing
- This will fix the failed workflow run: https://github.com/mPokornyETM/vs-code-wincc-oa-projects-viewer/actions/runs/19116408354/job/54626713618

### Related
- Fixes failed release workflow for v2.2.0
- No functional changes to publishing logic
- Only workflow configuration improvement
