### PR TITLE
hotfix: prevent automatic releases on every main push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: Release
 
 on:
-    push:
+    pull_request:
+        types: [closed]
         branches: [main, master]
     workflow_dispatch:
         inputs:
@@ -61,7 +62,11 @@ jobs:
     release:
         runs-on: ubuntu-latest
         needs: test
-        if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.event_name == 'workflow_dispatch'
+        # Only run on merged release PRs or manual workflow dispatch
+        if: |
+            github.event_name == 'workflow_dispatch' || 
+            (github.event.pull_request.merged == true && 
+             (startsWith(github.head_ref, 'release/') || contains(github.event.pull_request.labels.*.name, 'release')))
         outputs:
             version: ${{ steps.release.outputs.version }}
             changelog: ${{ steps.changelog.outputs.changelog }}
@@ -368,7 +373,7 @@ jobs:
     publish-marketplace:
         runs-on: ubuntu-latest
         needs: [test, release]
-        if: success() && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
+        if: success()
 
         steps:
             - name: Checkout repository


### PR DESCRIPTION
## 🐛 Hotfix: Prevent Automatic Releases on Every Push

### Problem

The release workflow was triggering on **every** push to main, including hotfixes and non-release merges. This caused:

- v3.0.0 release created from PR #35 merge
- v2.3.0 release created from PR #36 (hotfix) merge
- Version mismatch: package.json shows 2.2.0 but releases show 2.3.0

### Root Cause

The workflow was configured to trigger on:
```yaml
on:
  push:
    branches: [main, master]
```

This means ANY push to main triggered a new release, which is not what we want.

### Solution

Changed the workflow to only trigger on:

1. **Merged release PRs**: PRs from `release/*` branches or with `release` label
2. **Manual workflow dispatch**: When manually triggered

New trigger configuration:
```yaml
on:
  pull_request:
    types: [closed]
    branches: [main, master]
  workflow_dispatch:
```

With condition:
```yaml
if: |
  github.event_name == 'workflow_dispatch' || 
  (github.event.pull_request.merged == true && 
   (startsWith(github.head_ref, 'release/') || contains(github.event.pull_request.labels.*.name, 'release')))
```

### Changes

- Modified `.github/workflows/release.yml`:
  - Changed trigger from `push` to `pull_request` with `closed` type
  - Added condition to check for release branches or release label
  - Simplified `publish-marketplace` condition

### Cleanup Done

- Deleted incorrect v3.0.0 release and tag
- Deleted incorrect v2.3.0 release and tag  
- v2.2.0 remains as the correct current version

### Impact

- ✅ Hotfixes to main will NOT trigger releases
- ✅ Only release PRs (from `release/*` branches) will trigger releases
- ✅ Follows proper Git Flow release process
- ✅ Prevents version mismatch issues
